### PR TITLE
Allow custom statsd usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,7 @@ group :development do
   # gem "rcov", ">= 0"
 end
 
-gem 'jamster-statsd'
+if !ENV['CUSTOM_STATSD']
+  # A custom statd client is being used
+  gem 'jamster-statsd'
+end

--- a/lib/resque-statsd.rb
+++ b/lib/resque-statsd.rb
@@ -1,17 +1,11 @@
 require 'rubygems'
-require 'statsd' # Really Jnunemakers's mine branch of statsd 
 require 'resque/plugins/statsd'
-
-# Set up the client
-$resque_statsd = Statsd.new(ENV['GRAPHITE_HOST'], 8125)
-$resque_statsd.namespace="#{ENV['APP_NAME']}_#{ENV['RAILS_ENV']}.resque"
-
 
 module Resque
   module Plugins
     module Statsd
 
-      VERSION = "0.0.1"
+      VERSION = "0.0.2"
       
     end
   end

--- a/lib/resque/plugins/statsd.rb
+++ b/lib/resque/plugins/statsd.rb
@@ -1,29 +1,44 @@
 module Resque
   module Plugins
     module Statsd
+      @@resque_statsd = nil
+
+      def self.statsd_client
+        if @@resque_statsd.nil?
+          # Set up the client once
+          require 'statsd'
+          @@resque_statsd = Statsd.new(ENV['GRAPHITE_HOST'], 8125)
+          @@resque_statsd.namespace="#{ENV['APP_NAME']}_#{ENV['RAILS_ENV']}.resque"
+        end
+        return @@resque_statsd
+      end
 
       def after_enqueue_statsd(*args)
-        $resque_statsd.increment("#{@queue}.enqueued")
-        $resque_statsd.increment("total.enqueued")
-        
+        self.statsd_client.increment("#{@queue}.enqueued")
+        self.statsd_client.increment("total.enqueued")
       end
       
       def after_perform_statsd(*args)
-        $resque_statsd.increment("#{@queue}.finished")
-        $resque_statsd.increment("total.finished")
+        self.statsd_client.increment("#{@queue}.finished")
+        self.statsd_client.increment("total.finished")
       end
       
       def on_failure_statsd(*args)
-        $resque_statsd.increment("#{@queue}.failed")
-        $resque_statsd.increment("total.failed")
+        self.statsd_client.increment("#{@queue}.failed")
+        self.statsd_client.increment("total.failed")
       end
-      
+
       def around_perform_statsd(*args)
-        $resque_statsd.time("#{@queue}.processed") do 
+        self.statsd_client.time("#{@queue}.processed") do
           yield
         end
       end
 
+      def self.increment_metric(metric)
+        # Automatically appends queue name to the parameter
+        # before incrementing
+        self.statsd_client.increment("#{@queue}.#{metric}")
+      end
     end
   end
 end

--- a/resque-statsd.gemspec
+++ b/resque-statsd.gemspec
@@ -1,0 +1,12 @@
+Gem::Specification.new do |s|
+ s.name        = 'resque-statsd'
+ s.version     = '0.0.2'
+ s.homepage    = 'http://github.com/jamster/resque-statsd'
+ s.license     = 'MIT'
+ s.summary     = 'Adds simple counters and timers for statsd into your Resque jobs'
+ s.description = "Will add a counter for enqueuing, performing, failing and timing Jobs"
+ s.email       = "jayamster@gmail.com"
+ s.authors     = ["Jason Amster"]
+ s.files       = ["lib/resque-statsd.rb"]
+end
+

--- a/resque-statsd.gemspec
+++ b/resque-statsd.gemspec
@@ -7,6 +7,6 @@ Gem::Specification.new do |s|
  s.description = "Will add a counter for enqueuing, performing, failing and timing Jobs"
  s.email       = "jayamster@gmail.com"
  s.authors     = ["Jason Amster"]
- s.files       = ["lib/resque-statsd.rb"] + Dir["lib/resque/*"]
+ s.files       = ["lib/resque-statsd.rb", "lib/resque/plugins/statsd.rb"]
 end
 

--- a/resque-statsd.gemspec
+++ b/resque-statsd.gemspec
@@ -7,6 +7,6 @@ Gem::Specification.new do |s|
  s.description = "Will add a counter for enqueuing, performing, failing and timing Jobs"
  s.email       = "jayamster@gmail.com"
  s.authors     = ["Jason Amster"]
- s.files       = ["lib/resque-statsd.rb"]
+ s.files       = ["lib/resque-statsd.rb"] + Dir["lib/resque/*"]
 end
 


### PR DESCRIPTION
The default jamster-statsd is used if a custom statsd is not passed through the env variable.
